### PR TITLE
Use ::after height for content footer

### DIFF
--- a/src/styled/viewerScreen/ViewerScreen.styled.js
+++ b/src/styled/viewerScreen/ViewerScreen.styled.js
@@ -178,8 +178,10 @@ const PageContents = ViewerContents.extend`
     display: flex; align-items: center; justify-content: center;
   }
   .pages {
-    & > :last-child {
-      margin-bottom: ${() => screenHeight() - 1}px !important;
+    &::after {
+      content: '';
+      display: block;
+      padding-bottom: ${() => screenHeight() - 1}px;
     }
   }
   .comic_page {


### PR DESCRIPTION
## 변경사항
다단 레이아웃과 함께 `margin-bottom` 을 쓰는 것은 브라우저간 (특히 사파리에서) 렌더 결과 불일치를 가져옵니다.
`react-viewer@0.3` 에서는 content footer에 해당 스타일을 사용하고 있으며 이로 인해 페이지 계산에 문제가 생기게 되어 `::after + padding-bottom` 으로 변경하였습니다.